### PR TITLE
JAN week 1

### DIFF
--- a/H-index.kt
+++ b/H-index.kt
@@ -1,0 +1,12 @@
+class Solution {
+    fun solution(citations: IntArray): Int {
+        var answer = 0
+        val sorted = citations.sortedDescending()
+        sorted.forEachIndexed { i, c ->
+            if (c >= i + 1) {
+                answer = i + 1
+            }
+        }
+        return answer
+    }
+}


### PR DESCRIPTION
### H-index

#### 소요 시간
> 1시간

#### 간단 풀이 방식
- 논문 수를 편하게 세기 위해, citations를 역순으로 정렬
- 인용횟수가 많은 논문부터 개수를 세며, 현재 논문 인용 수가 세어진 논문보다 많은 지 체크
- 그 중 가장 적은 인용 수를 가진 논문의 번호를 답으로 지정 후 반환
- 인용 수에서 답을 찾지 않고, 논문의 수에서 답을 찾은 게 포인트였습니다

#### Pseudo Code
```kotlin
citations.sortedDescending()
        sorted.forEachIndexed { i, c ->
            if (c >= i + 1) {
                answer = i + 1
            }
        }
```

#### 메모리
- 최소: 64.9MB
- 최대: 66.9MB
#### 시간
- 최소: 19.47ms
- 최대: 628.73ms