### PR TITLE
JAN_week3_truck_crossing_bridge

### DIFF
--- a/week3/truck_crossing_bridge.kt
+++ b/week3/truck_crossing_bridge.kt
@@ -1,0 +1,18 @@
+import java.util.ArrayDeque
+
+class Solution {
+    fun solution(bridge_length: Int, weight: Int, truck_weights: IntArray): Int {
+        var answer = 0
+        val throughBridges = mutableListOf<Int>()
+        val waitingQueue = ArrayDeque(truck_weights.asList())
+        val crossingQueue = ArrayDeque<Pair<Int, Int>>()
+        while (throughBridges != truck_weights.asList()) {
+            answer++
+            if (crossingQueue.isNotEmpty() && answer - crossingQueue.firstOrNull()!!.second == bridge_length)
+                throughBridges.add(crossingQueue.pollFirst().first)
+            if (waitingQueue.isNotEmpty() && crossingQueue.sumOf { it.first } + waitingQueue.firstOrNull()!! <= weight)
+                crossingQueue.offer(waitingQueue.pollFirst() to answer)
+        }
+        return answer
+    }
+}


### PR DESCRIPTION
## 다리를 지나는 트럭

### 소요 시간
> 30분

### 간단 풀이 방식
- 대기 트럭큐, 다리를 건너고 있는 트럭큐, 다리를 지난 트럭 리스트를 만들어 관리했다.
- 다리를 건너고 있는 트럭큐는 Pair타입을 요소로 가진다.
	- Pair는 본인의 무게와, 본인이 다리를 진입한 타이밍(현재 시간: answer)를 쌍으로 가진다.
- 다리를 지난 트럭 리스트와 인자로 주어진 truck_weights가 같아질 때까지 초(answer)를 늘렸다
- 그러다가 다리에 트럭이 추가되어도 다리를 건너고 있는 트럭의 무게 합이 weight보다 낮으면, 대기 트럭큐에서 Dequeue를 하여 다리를 건너고 있는 트럭큐에 Enqueue했다.
- 포인트는 어떤 타이밍에 트럭이 다리를 빠져나가, 다리를 지난 트럭 리스트가 채워지냐 였다.
	- 트럭은 늦게 들어가면 들어갔지, 들어간 순간부터 정체라는 건 존재하지 않는다.
	- 때문에, 본인이 다리에 들어가고 나서 다리 길이만큼만 시간이 지난다면, 바로 다리를 빠져나가야 한다
	- 이 때문에 다리를 건너고 있는 트럭큐에 다리를 진입한 타이밍(현재시간: answer)를 넣은 것이다.
	- 그래서 시간이 증가되고, 다리에 트럭 진입 여부를 판단하기 전, 다리를 건너고 있는 트럭큐의 front에 다리길이만큼의 시간 동안 다리에 있었던 트럭은 다리를 지난 트럭 리스트로 이주시켰다.

### Pseudo Code
```kotlin
// val crossingQueue: ArrayDeque<Pair<Int, Int>>
while (throughBridges != truck_weights.asList()) {  
    answer++  
    if (crossingQueue.isNotEmpty() && answer - crossingQueue.firstOrNull()!!.second == bridge_length)  
        throughBridges.add(crossingQueue.pollFirst().first)  
    if (waitingQueue.isNotEmpty() && crossingQueue.sumOf { it.first } + waitingQueue.firstOrNull()!! <= weight)  
        crossingQueue.offer(waitingQueue.pollFirst() to answer)  
}
```

### 메모리
- 최소: 64.9MB
- 최대: 81.3MB
### 시간
- 최소: 18.77ms
- 최대: 393.50ms