### PR TITLE
JAN_week4_find_prime_number

### DIFF
--- a/week4/find_prime_number.kt
+++ b/week4/find_prime_number.kt
@@ -1,0 +1,19 @@
+import kotlin.math.sqrt
+
+class Solution {
+    fun getAllNums(curr: String, remain: String, allNums: MutableList<Int>) {
+        if (curr.isNotEmpty())
+            allNums.add(curr.toInt())
+        remain.forEachIndexed { i, r ->
+            getAllNums(curr + r, remain.substring(0, i) + remain.substring(i + 1), allNums)
+        }
+    }
+    fun solution(numbers: String): Int {
+        val allNums = mutableListOf<Int>()
+        getAllNums("", numbers, allNums)
+        return allNums.distinct().filter { num ->
+            if (num <= 1) false
+            else (2..sqrt(num.toDouble()).toInt()).all { num % it != 0 }
+        }.size
+    }
+}


### PR DESCRIPTION
## 소수 찾기

### 소요 시간
> 1시간 59분

### 간단 풀이 방식
- 만들 수 있는 모든 숫자를 만들고
- 중복을 제거
- 그 중 2부터 차례대로 나눠서 본인 수 -1까지 나눠떨어지지 않는 수들
- 의 개수

### 고민파트
- 만들 수 있는 모든 숫자를 만들기 위한 방법으로, 재귀가 잘 떠오르지 않아 인터넷을 뒤졌다.
- 2시간을 넘으면 답을 찾아보기로 했지만, 재귀를 사용할 줄 아는게 주목적이라 생각해 재귀를 공부하고 스스로 짰다.
- 어쩌다 보니 아리토스테네스의 체까지 검색결과에 걸쳐져서, 제곱근을 이용하여 최적화할 수 있었던 게 기억나 적용했다.
	- 실제로 최대시간은 4배 이상, 시간평균은 2배 가까이 줄어들었다.
	- sqrt의 결과가 Double이라 toInt로 값이 버려지면 문제가 생길 것 같았는데 생기지 않았다.
	- 생각해보니 그게 맞았다. 모순을 증명하면 다음과 같다
		- 23의 제곱근은 4.xx..이다.
		- 만약 5이상의 자연수로 나눠떨어질 수 있다고 생각하면, 그 몫은 5보단 작아야한다.
		- 왜냐하면 $5 * x = 23$인데, $x >= 5$라면 $5 * x >= 25$기 때문
		- 그러므로 5보다 작은 자연수 중 제일 큰 수는 4이고, 그러면 제곱근을 4로 퉁쳐도 어차피 이 몫인 4는 범위에 포함되기 때문에, toInt()로 소수부는 버려도 상관없다.

### Pseudo Code
```kotlin
fun getAllNums(curr: String, remain: String, allNums: MutableList<Int>) {
        if (curr.isNotEmpty())
            allNums.add(curr.toInt())
        remain.forEachIndexed { i, r ->
            getAllNums(curr + r, remain.substring(0, i) + remain.substring(i + 1), allNums)
        }
    }
fun solution(numbers: String): Int {
	val allNums = mutableListOf<Int>()
	getAllNums("", numbers, allNums)
	return allNums.distinct().filter { num ->
		if (num <= 1) false
		else (2..sqrt(num.toDouble()).toInt()).all { num % it != 0 }
	}.size
}
```

### 메모리
- 최소: 64.4MB
- 최대: 75.2MB
### 시간
- 최소: 16.67ms
- 최대: 33.59ms