### PR TITLE
JAN_week4_fatigue

### DIFF
--- a/week4/fatigue.kt
+++ b/week4/fatigue.kt
@@ -1,0 +1,34 @@
+class Solution {
+    fun getCombinations(curr: Array<IntArray>, remain: Array<IntArray>, dungeonCombs: MutableList<Array<IntArray>>) {
+        if (curr.isNotEmpty())
+            dungeonCombs.add(curr)
+        remain.forEachIndexed { i, it ->
+            getCombinations(
+                curr + it,
+                (remain.slice(0 until i) + remain.slice(i+1 until remain.size)).toTypedArray(),
+                dungeonCombs
+            )
+        }
+    }
+    fun solution(k: Int, dungeons: Array<IntArray>): Int {
+        val dungeonCombs = mutableListOf<Array<IntArray>>()
+        getCombinations(arrayOf(), dungeons, dungeonCombs)
+        var highestCount = 0
+        dungeonCombs.forEach { dungeonComb ->
+            var count = 0
+            var fatigue = k
+            run {
+                dungeonComb.forEach {
+                    if (fatigue >= it[0]) {
+                        fatigue -= it[1]
+                        if (++count == dungeons.size)
+                            return count
+                        if (highestCount < count)
+                            highestCount = count
+                    } else return@run
+                }
+            }
+        }
+        return highestCount
+    }
+}

--- a/week4/fatigue.kt
+++ b/week4/fatigue.kt
@@ -1,34 +1,17 @@
 class Solution {
-    fun getCombinations(curr: Array<IntArray>, remain: Array<IntArray>, dungeonCombs: MutableList<Array<IntArray>>) {
-        if (curr.isNotEmpty())
-            dungeonCombs.add(curr)
-        remain.forEachIndexed { i, it ->
-            getCombinations(
-                curr + it,
-                (remain.slice(0 until i) + remain.slice(i+1 until remain.size)).toTypedArray(),
-                dungeonCombs
-            )
-        }
-    }
     fun solution(k: Int, dungeons: Array<IntArray>): Int {
-        val dungeonCombs = mutableListOf<Array<IntArray>>()
-        getCombinations(arrayOf(), dungeons, dungeonCombs)
-        var highestCount = 0
-        dungeonCombs.forEach { dungeonComb ->
-            var count = 0
-            var fatigue = k
-            run {
-                dungeonComb.forEach {
-                    if (fatigue >= it[0]) {
-                        fatigue -= it[1]
-                        if (++count == dungeons.size)
-                            return count
-                        if (highestCount < count)
-                            highestCount = count
-                    } else return@run
-                }
+        var answer: Int = 0
+        dungeons.forEachIndexed { i, dungeon ->
+            if (k >= dungeon[0]) {
+                val explore = 1 + solution(
+                    k - dungeon[1],
+                    dungeons.sliceArray(0 until i) + dungeons.sliceArray(i + 1 until dungeons.size)
+                )
+                answer = maxOf(answer, explore)
+                if (answer == dungeons.size)
+                    return answer
             }
         }
-        return highestCount
+        return answer
     }
 }


### PR DESCRIPTION
## 피로도

### 소요 시간
> 1시간 30분

### 간단 풀이 방식
- 초기 dungeons를 순회하며, 모든 순열의 던전을 재귀로 탐험한다.
	- 현재 피로도가 최소필요필요도보다 작거나 같으면, 탐험 횟수 증가 하며 현재 던전을 제외한 다른 던전들로 탐험
	- 탐험회수와 answer를 비교하여 더 큰 값을 answer에 할당
	- 만약 탐험 도중 탐험할 던전 수만큼 이미 탐험했다면, answer 반환
- 최대 탐험 회수가 할당된 anwer 반환

### 고민파트
- 처음엔 모든 가능한 순열의 dungeons배열을 구해서, 그 배열을 순회하며 answer를 증가시켰다.
- 모든 가능한 순열을 구하는 과정에서, [[소수 찾기]]처럼 재귀를 사용했다. 40여분 쯤 걸렸다.
- 하지만, 다른 답을 보니, solution자체를 재귀함수로 사용할 수 있는 걸 본 후, 처음부터 다시 짜버렸다.
- 헤맸던 부분은 재귀함수를 돌리는 반복문에서, 돌릴 때마다 탐험횟수가 증가되면 안 된다는거였다.
- 때문에 answer를 증가시키는 게 아닌, 재귀함수의 반환 값에 1을 더해 explore를 증가시키는 방향으로 짰다.
### Pseudo Code
```kotlin
fun solution(k: Int, dungeons: Array<IntArray>): Int {
	var answer: Int = 0
	dungeons.forEachIndexed { i, dungeon ->
		if (k >= dungeon[0]) {
			val explore = 1 + solution(
				k - dungeon[1],
				dungeons.sliceArray(0 until i) + dungeons.sliceArray(i + 1 until dungeons.size)
			)
			answer = maxOf(answer, explore)
			if (answer == dungeons.size)
				return answer
		}
	}
	return answer
}
```

### 메모리
- 최소: 64.5MB
- 최대: 72.5MB
### 시간
- 최소: 16.47ms
- 최대: 32.10ms