### PR TITLE
JAN_week4_vowel_dict

### DIFF
--- a/week4/vowel_dict.kt
+++ b/week4/vowel_dict.kt
@@ -1,0 +1,16 @@
+class Solution {
+    val sequence = "AEIOU"
+    val vowelDict = mutableListOf<String>()
+
+    fun getList(curr: String) {
+        if (curr.length == 6) return
+        vowelDict.add(curr)
+        sequence.forEach {
+            getList(curr + it)
+        }
+    }
+    fun solution(word: String): Int {
+        getList("")
+        return vowelDict.indexOf(word)
+    }
+}


### PR DESCRIPTION
## 모음사전

### 소요 시간
> 20분

### 간단 풀이 방식
- 재귀를 이용해 모음사전에 순서대로 삽입한다.
	- 단, 빈 문자열도 삽입했기 때문에 index는 1개 늘어남
- 찾고자 하는 word의 index를 반환한다
	- index는 늘어났지만, 애초에 순서는 1부터 시작하므로 딱 맞음

### 고민파트
- 처음엔 모든 순열 찾고 (사전 순)정렬한 뒤, index를 반환하면 될 줄 알았다.
- 근데 여태 해왔던 순열 찾기는 요소의 중복을 허용하지 않은 것이였다.
- 어떻게 약간만 바꾸면 될 것 같아, 그림 그려보며 짱구를 굴리니 더 심플하게 나왔다.
### Pseudo Code
```kotlin
val sequence = "AEIOU"
val vowelDict = mutableListOf<String>()

fun getList(curr: String) {
	if (curr.length == 6) return
	vowelDict.add(curr)
	sequence.forEach {
		getList(curr + it)
	}
}
fun solution(word: String): Int {
	getList("")
	return vowelDict.indexOf(word)
}
```

### 메모리
- 최소: 63.6MB
- 최대: 66.6MB
### 시간
- 최소: 16.41ms
- 최대: 25.54ms