### PR TITLE
JAN_week5_network

### DIFF
--- a/week5/network.kt
+++ b/week5/network.kt
@@ -1,0 +1,20 @@
+class Solution {
+    fun solution(n: Int, computers: Array<IntArray>): Int {
+        var answer = 0
+        val visited = BooleanArray(n)
+        fun dfs(i: Int) {
+            visited[i] = true
+            computers[i].forEachIndexed { idx, it ->
+                if (idx != i && it == 1 && !visited[idx])
+                    dfs(idx)
+            }
+        }
+        (0 until n).forEach {
+            if (!visited[it]) {
+                answer++
+                dfs(it)
+            }
+        }
+        return answer
+    }
+}


### PR DESCRIPTION
## 네트워크

### 소요 시간
> 10분

### 간단 풀이 방식
- computers를 인접행렬방식의 그래프라고 생각하고, 방문하지 않은 모든 노드에서 dfs를 수행했다.
- dfs처음 실행시 새로운 네트워크라 판단, 답을 증가시켰다.
- 원래 인접행렬에 본인이 1이어야 하는진 모르겠으나, 본인을 제외하고 1인 경우를 인접한 경우라고 생각했다.

### Pseudo Code
```kotlin
val visited = BooleanArray(n)
fun dfs(i: Int) {
	visited[i] = true
	computers[i].forEachIndexed { idx, it ->
		if (idx != i && it == 1 && !visited[idx])
			dfs(idx)
	}
}
(0 until n).forEach {
	if (!visited[it]) {
		answer++
		dfs(it)
	}
}
```

### 메모리
- 최소: 62.9MB
- 최대: 65.2MB
### 시간
- 최소: 3.15ms
- 최대: 4.73ms