### PR TITLE
JAN_week5_convert_word

### DIFF
--- a/week5/convert_word.kt
+++ b/week5/convert_word.kt
@@ -1,0 +1,30 @@
+class Solution {
+    fun solution(begin: String, target: String, words: Array<String>): Int {
+        if (!words.contains(target))
+            return 0
+        val newWords = arrayOf(begin) + words
+        val visited = BooleanArray(newWords.size)
+        fun isAdj(word: String, adjWord:String): Boolean {
+            return word.mapIndexed { i, c ->
+                if (c != adjWord[i]) 1 else 0
+            }.sum() == 1
+        }
+//         bfs
+        val queue = ArrayDeque<Pair<Int, Int>>()
+        queue.addLast(0 to 0)
+        visited[0] = true
+        while (queue.isNotEmpty()) {
+            val (front, depth) = queue.removeFirst()
+            if (newWords[front] == target) {
+                return depth
+            }
+            visited.forEachIndexed { i, v ->
+                if (!v && isAdj(newWords[front], newWords[i])) {
+                    queue.addLast(i to depth + 1)
+                    visited[i] = true
+                }
+            }
+        }
+        return -1
+    }
+}


### PR DESCRIPTION
## 단어 변환

### 소요 시간
> 1시간 30분

### 간단 풀이 방식
- isAdj함수를 통해 한 글자만 다른 문자열 여부를 구해, 이를 인접한 노드라고 생각하는 그래프를 만들어, bfs로 최단 경로를 구한다.
- 큐에는 인덱스와 depth를 넣어, front의 문자열이 target과 같을 때 depth를 retrun한다.
- 단, words에 target이 존재하지 않으면 바로 0을 return한다.

### 고민파트
- 처음의 isAdj함수는 word와 adjWord를 이중 순회하며 여부를 판단했다.
	- 하지만 어차피 글자 수가 같아서, 같은 글자의 수를 세어 그 수가 1인지만 판단하면 됐다.
- 처음엔 그래프도 isAdj를 활용하여 순순히 배열<변환가능리스트>로 만들어서 정보에 맞게 삽입했다.
	- 하지만 어차피 (인접노드를 순회하며, 방문가능한 노드)를 큐에 넣는거라면,
	  (방문가능 노드를 순회하며, 인접노드)를 큐에 넣는 것과 같다고 판단했다.
	- 그렇다면 굳이 그래프 생성 없이, 인접 여부만 확인해도 큐에 넣을 수 있었다.
	- 덕분에 메모리와 코드 양을 획기적으로 줄일 수 있었다.
- 아마 각 노드의 인접한 노드 수가 모든 노드의 수보단 적기에, 반복문은 시간적으로는 조금 더 들 것이다.
	- 하지만 그 차이의 합이 그래프를 만드는 시간인 $(word.size + 1)^2$ 보단 작을 것 같다.
### Pseudo Code
```kotlin
if (!words.contains(target))
	return 0
val newWords = arrayOf(begin) + words
val visited = BooleanArray(newWords.size)
fun isAdj(word: String, adjWord:String): Boolean {
	return word.mapIndexed { i, c ->
		if (c != adjWord[i]) 1 else 0
	}.sum() == 1
}
//         bfs
val queue = ArrayDeque<Pair<Int, Int>>()
queue.addLast(0 to 0)
visited[0] = true
while (queue.isNotEmpty()) {
	val (front, depth) = queue.removeFirst()
	if (newWords[front] == target) {
		return depth
	}
	visited.forEachIndexed { i, v ->
		if (!v && isAdj(newWords[front], newWords[i])) {
			queue.addLast(i to depth + 1)
			visited[i] = true
		}
	}
}
return -1
```

### 메모리
- 최소: 64.7MB
- 최대: 67.0MB
### 시간
- 최소: 13.81ms
- 최대: 24.05ms