### PR TITLE
JAN_week5_travel_route

### DIFF
--- a/week5/travel_route.kt
+++ b/week5/travel_route.kt
@@ -1,0 +1,26 @@
+class Solution {
+    fun solution(tickets: Array<Array<String>>): List<String> {
+        var visiteds = arrayOf<Array<Int>>()
+        val newTickets = arrayOf(arrayOf("", "ICN")) + tickets
+        val queue = ArrayDeque <Pair<Int, Array<Int>>>()
+        queue.addLast(0 to arrayOf(0))
+        while (queue.isNotEmpty()) {
+            val (index, visited) = queue.removeFirst()
+            if (visited.size == newTickets.size)
+                visiteds += visited
+            newTickets.indices.filter { !visited.contains(it) }.forEach {
+                if (newTickets[index][1] == newTickets[it][0]) {
+                    queue.addLast(it to visited + arrayOf(it))
+                }
+            }
+        }
+        return visiteds.map { it.map { i -> newTickets[i] } }.sortedBy {
+            it.toTypedArray().flatten().joinToString("")
+        }.first().drop(1).mapIndexed { i, ticket ->
+            when (i) {
+                tickets.lastIndex -> ticket.toList()
+                else -> listOf(ticket[0])
+            }
+        }.flatten()
+    }
+}


### PR DESCRIPTION
## 여행 경로

### 소요 시간
> 1시간 15분

### 간단 풀이 방식
- bfs방식으로 풀이했으나, visited를 탐색 경로 전체에서의 노드 방문 여부로 하지 않았다.
	- 큐의 타입을 <노드인덱스, 여태 방문한 노드 인덱스들> 로 설정했다.
	- 그래서 노드를 방문할 때마다, 나만의 visited를 만들면서 가지고 다녔다.
	- 이렇게 함으로써, 분기가 갈라질 때마다 다른 visited를 가지게 된다.
- 큐에 들어가는 인덱스는 newTickets(tickets의 맨 앞에 시작 노드(["", ICN])를 더한 배열)의 인덱스 정보이다
- 인접 노드 판단 기준은 `나의 1번째 요소가 방문할 노드의 0번째 요소와 같으면`이다.
	- 여기서 나는 사실 인덱스겠지만, newTickets[인덱스]라고 생각하자.
- 탐색을 진행하면서 모든 항공권을 다 탐색했다면, visiteds에 추가한다.
- visiteds는 모든 항공권을 다 탐색 성공한, newTickets의 인덱스로 이루어진, 경로들이 있게 된다.
- 이를 newTicket에 접근해 사전 순으로 정렬하여 제일 앞선 경로를 선택, 시작 노드(["", ICN])를 지운다.
- 그 값에서 첫번 째 도시만을 취하여 배열을 만들어 반환한다.
	- 단, 경로(항공권)의 마지막은 도착지까지 포함한다.

### Pseudo Code
```kotlin
val queue = ArrayDeque <Pair<Int, Array<Int>>>()
queue.addLast(0 to arrayOf(0))
while (queue.isNotEmpty()) {
	val (index, visited) = queue.removeFirst()
	if (visited.size == newTickets.size)
		visiteds += visited
	newTickets.indices.filter { !visited.contains(it) }.forEach {
		if (newTickets[index][1] == newTickets[it][0]) {
			queue.addLast(it to visited + arrayOf(it))
		}
	}
}
return visiteds.map { it.map { i -> newTickets[i] } }.sortedBy {
	it.toTypedArray().flatten().joinToString("")
}.first().drop(1).mapIndexed { i, ticket ->
	when (i) {
		tickets.lastIndex -> ticket.toList()
		else -> listOf(ticket[0])
	}
}.flatten()
```

### 메모리
- 최소: 66.5MB
- 최대: 65.2MB
### 시간
- 최소: 24.96ms
- 최대: 898.36ms