### PR TITLE
JAN_week8_immigration

### DIFF
--- a/week8/immigration.kt
+++ b/week8/immigration.kt
@@ -1,0 +1,19 @@
+class Solution {
+    fun solution(n: Int, times: IntArray): Long {
+        var answer: Long = 0
+        var start: Long = 1
+        var end: Long = 1_000_000_000_000_000_000
+        while (start <= end) {
+            val mid = (start + end) / 2
+            var enterPeople: Long = 0
+            times.forEach { enterPeople += mid / it }
+            if (n <= enterPeople) {
+                answer = mid
+                end = mid - 1
+            }
+            else
+                start = mid + 1
+        }
+        return answer
+    }
+}


### PR DESCRIPTION
## 입국심사

### 소요 시간
> 1시간 반

### 간단 풀이 방식
- 가능한 시간의 범위인 1부터 10억 * 10억 안에서 이분탐색을 통해 조건에 해당하는 최소시간을 구한다.
- 현재 시간(mid)일 때 최대로 가능한 입국자수를 구한 뒤, n과 비교하여 더 많으면 탐색 끝 범위를 줄이고, 그게 아니면 시작범위를 줄인다.
	- 최대 가능 입국자 수는 mid시간 안에 각 심사대에서 심사할 수 있는 최대인원을 모두 더한 것이다.
	- 즉, mid를 times의 각 요소들로 나눈 몫을 모두 더해 구한다.
- 단, 예외를 커버하기 위해, 답은 n과 비교하여 더 많거나 같을 때 갱신한다.
### 고민파트
- 최대 가능 입국자 수까지 20분 안에 구하여 제출하였으나, 무조건 그렇게 해서 구한 mid가 답이라 생각했다.
- 하지만 이러한 예외케이스들을 뚫을 수 없었다.
	- 4, [1, 2, 3], 기댓값: 3
- 3분일 때 가능한 경우의 수는
	- 1심사대 3명, 2심사대 1명
	- 1심사대 2명, 2심사대 1명, 3심사대 1명
- 하지만 1심사대 3명, 2심사대 1명, 3심사대 1명으로 최대 5명도 3분 안에 가능하다.
- 이 때문에, mid가 3일 때 최대 가능 입국자수가 5가 나오게 되어, n과 비교하여 더 많은 것으로 판단하여 mid를 찾을 범위를 변경하게 된다.
- 그래서 mid를 모든 경우의 답이라고 생각하면 안 되고, n과 비교하여 많거나 같을 때의 mid를 답으로 취해가면 된다.
	- 그런 과정 속에서 반복문이 종료될 때까지 반복하면, 최후의 답은 n과 같을 때의 mid거나, 그 순간이 없다면 가장 가까운 n보다 제일 조금만 큰 최대가능 입국자수를 구하게 한 mid가 답으로 최종적으로 취해진다.
### Pseudo Code
```kotlin
while (start <= end) {
	val mid = (start + end) / 2
	var enterPeople: Long = 0
	times.forEach { enterPeople += mid / it }
	if (n <= enterPeople) {
		answer = mid
		end = mid - 1
	}
	else
		start = mid + 1
}
return answer
```

### 메모리
- 최소: 62.2MB
- 최대: 69.2MB
### 시간
- 최소: 0.06ms
- 최대: 53.70ms