### PR TITLE
JAN_week8_furthest_node

### DIFF
--- a/week8/furthest_node.kt
+++ b/week8/furthest_node.kt
@@ -1,0 +1,22 @@
+class Solution {
+    fun solution(n: Int, edge: Array<IntArray>): Int {
+        val visited = Array(n + 1) { false to 0}
+        val queue = ArrayDeque<Pair<Int, Int>>()
+        queue.addLast(1 to 0)
+        visited[1] = true to 0
+        while (queue.isNotEmpty()) {
+            val (front, depth) = queue.removeFirst()
+            edge.forEach {
+                if (it[0] == front && !visited[it[1]].first) {
+                    queue.addLast(it[1] to depth + 1)
+                    visited[it[1]] = true to depth + 1
+                }
+                else if (it[1] == front && !visited[it[0]].first) {
+                    queue.addLast(it[0] to depth + 1)
+                    visited[it[0]] = true to depth + 1
+                }
+            }
+        }
+        return visited.filter { node -> node.second == visited.maxOf { it.second } }.size
+    }
+}


### PR DESCRIPTION
## 가장 먼 노드

### 소요 시간
> 45분
### 간단 풀이 방식
- 큐와 bfs를 활용한 풀이로, visited의 크기를 n + 1로 두어 노드 방문을 쉽게 할 수 있게 하였다.
- visited 요소 타입을 Boolean으로만 두는 것이 아니라, Pair<Boolean, Int>로 함으로서 방문시 depth까지 가질 수 있도록 하였다.
- bfs가 끝나고 나면, 0번째 인덱스를 제외한 모든 it.first의 값이 true인 visited가 나올테고,
  그 visited의 it.second들 중 max인 요소들의 수를 구하여 답을 구했다.
### 고민파트
- dfs/bfs에서 다뤘던 그래프가 잘 기억이 안 나, dfs로 접근했다가 원하는 답을 구하지 못 하고 헤메며 시간을 썼다. bfs를 통한 풀이를 해야 깊은 순서대로 방문하기에, 내 풀이에선 bfs만이 유일한 풀이였다.
### Pseudo Code
```kotlin
while (queue.isNotEmpty()) {
	val (front, depth) = queue.removeFirst()
	edge.forEach {
		if (it[0] == front && !visited[it[1]].first) {
			queue.addLast(it[1] to depth + 1)
			visited[it[1]] = true to depth + 1
		}
		else if (it[1] == front && !visited[it[0]].first) {
			queue.addLast(it[0] to depth + 1)
			visited[it[0]] = true to depth + 1
		}
	}
}
return visited.filter { node -> node.second == visited.maxOf { it.second } }.size
```

### 메모리
- 최소: 65.1MB
- 최대: 89.0MB
### 시간
- 최소: 17.00ms
- 최대: 9027.99ms