### PR TITLE
JAN_week8_ranking

### DIFF
--- a/week8/ranking.kt
+++ b/week8/ranking.kt
@@ -1,0 +1,27 @@
+class Solution {
+    fun solution(n: Int, results: Array<IntArray>): Int {
+        var answer = 0
+        val graph = Array(n + 1) { Array(n + 1) {0} }
+        results.forEach { (a, b) ->
+            graph[a][b] = 1
+        }
+        for (i in 1..n) {
+            for (j in 1..n) {
+                for (k in 1..n) {
+                    if (graph[j][i] == 1 && graph[i][k] == 1)
+                        graph[j][k] = 1
+                }
+            }
+        }
+        for (i in 1..n) {
+            var count = 0
+            for (j in 1..n) {
+                if (graph[i][j] == 1 || graph[j][i] == 1)
+                    count++
+            }
+            if (count == n - 1)
+                answer++
+        }
+        return answer
+    }
+}


### PR DESCRIPTION
## 순위

### 소요 시간
> 30분 +@
### 간단 풀이 방식
- results를 통해 게임의 승패를 1 또는 0으로 표현한 인접행렬을 만들어, 나에 대한 승패횟수가 n-1인 놈들을 세어 답으로 구했다.
- 인접행렬을 만드는 과정은 다음과 같다.
	- 선수는 1부터 시작하니 편의를 위해 n+1 짜리 2차원 정사각행렬을 생성, 0으로 초기화
	- results를 순회하며 이긴 경우(a가 b에게 이겼다면, `[a][b]`)를 1로 할당
	- `[1][2]`,`[2][3]`이 1이면 `[1][3]`도 처리해야함
		- 이를 위해 중간점(2)를 기준으로 삼중반복 수행
### 고민파트
- `[1][2]`,`[2][3]`이 1일 때 `[1][3]`을 처리하는 과정에서, 처음엔 조건문을
  ```kotlin
	if (graph[i][j] == 1 && graph[j][k] == 1)  
	    graph[i][k] = 1
	```
	이렇게 직관적으로(?) i가 k에게 이기는 경우로 생각했다.
- 하지만 이런 순서대로 탐색하면, 위에서 언급한 `[1][3]`은 처리되지만, `[3][4]`에 대한 값은 없고(0), `[2][4]`가 1일 때는 처리가 되지 않는다. 즉, 한 다리 건너는 경우만 잘 처리된다.
- 때문에 검색을 했고, 플로이드-워셜을 알게되었다. 순회 순서가 달랐다.
- 맨 위 반복문에서 중간점이 될 선수를 반복하고, 2차 3차 반복문이 각각 시작,끝점이 될 선수를 반복해야 했다. 즉 i,j,k순 반복문이라면, `[j][i]`,`[i][k]`이처럼 i가 중간점이 되어 `[j][k]`를 찾아낸다.
```
```
### Pseudo Code
```kotlin
results.forEach { (a, b) ->
	graph[a][b] = 1
}
for (i in 1..n) {
	for (j in 1..n) {
		for (k in 1..n) {
			if (graph[j][i] == 1 && graph[i][k] == 1)
				graph[j][k] = 1
		}
	}
}
for (i in 1..n) {
	var count = 0
	for (j in 1..n) {
		if (graph[i][j] == 1 || graph[j][i] == 1)
			count++
	}
	if (count == n - 1)
		answer++
}
```

### 메모리
- 최소: 61.6MB
- 최대: 66.8MB
### 시간
- 최소: 0.05ms
- 최대: 19.90ms