### PR TITLE
JAN_week8_number_of_room

### DIFF
--- a/week8/number_of_room.kt
+++ b/week8/number_of_room.kt
@@ -1,0 +1,70 @@
+class Solution {
+    fun solution(arrows: IntArray): Int {
+        var answer = -1
+        val dir = listOf (
+            listOf(0, -1),
+            listOf(1, -1),
+            listOf(1, 0),
+            listOf(1, 1),
+            listOf(0, 1),
+            listOf(-1, 1),
+            listOf(-1, 0),
+            listOf(-1, -1),
+        )
+
+        var minX = 0
+        var maxX = 0
+        var minY = 0
+        var maxY = 0
+        var curX = 0
+        var curY = 0
+        arrows.forEach { arrow ->
+            repeat(4) {
+                curX += dir[arrow][0]
+                curY += dir[arrow][1]
+                minX = minOf(minX, curX)
+                maxX = maxOf(maxX, curX)
+                minY = minOf(minY, curY)
+                maxY = maxOf(maxY, curY)
+            }
+        }
+        val width = maxX - minX + 3
+        val height = maxY - minY + 3
+        val map = Array(height) { IntArray(width) }
+        val visited = Array(height) { BooleanArray(width) }
+
+        var x = -minX + 1
+        var y = -minY + 1
+        map[y][x] = 1
+        arrows.forEach { arrow ->
+            repeat(4) {
+                x += dir[arrow][0]
+                y += dir[arrow][1]
+                map[y][x] = 1
+            }
+        }
+
+        fun dfs(i: Int, j: Int) {
+            visited[i][j] = true
+            dir.filterIndexed { idx, it ->
+                idx % 2 != 1
+            }.forEach {
+                val x = j + it[0]
+                val y = i + it[1]
+                if (y in map.indices && x in map[y].indices &&
+                    !visited[y][x] && map[y][x] == 0)
+                    dfs(y, x)
+            }
+        }
+        map.forEachIndexed { i, it ->
+            it.indices.forEach { j ->
+                if (!visited[i][j] && map[i][j] == 0) {
+                    answer++
+                    dfs(i, j)
+                }
+            }
+        }
+
+        return answer
+    }
+}


### PR DESCRIPTION
## 방의 개수

### 소요 시간
> 실패
### 간단 풀이 방식
- 0 ~ 7에 해당되는 방향을 x, y좌표로 치환해 배열을 생성한다.
- arrows를 순회하며 최소/최대 x, y를 구하고, 이를 기반으로 그림을 그릴 map, 방문체크용 visited의 크기를 구한다(4배 적용)
- 벗어나지 않도록 적절한 초기 x, y를 설정하고, arrows를 순회하며 그림을 그린다(4배 적용)
- [[네트워크 문제풀이]]와 비슷하게 방문하지 않은 모든 0에서 dfs를 시작하며, answer를 증가한다.
- dfs 내부에서도, 현재 위치에서 동서남북을 체크하며, 방문하지 않은 0에 대해 다시 dfs를 실행시키며 방문처리 한다.
### 고민파트
- 수환이 형이 말해줬던, 안 되면 2배 해보기를 적용해야한다고 생각했다.
- 하지만 최대 엣지 케이스를 생각해보니 4배는 해야해서 그렇게 했다.
	- 대각선 이동을 이용하여 4개의 점으로 딱지모양을 그려보면, 제일 작은 도형인 삼각형 4개를 그릴 수 있다.
	- 이들 안에 0이 있도록 하여 빈 방을 세려면, 4배는 해야 점 1개가 생긴다.
- 4배기 때문에, 메모리를 최대한 적게 쓰기 위해 그림판을 최대한 작게 사용하려고 노력했다.
- 밖에 테두리(도형 밖 공간)을 만들기 위해 width, height에 각각 2씩 더해야 했고, answer는 -1부터 증가하도록 하였다.
- 초기값 x, y도 1을 offset으로 두어 도형 밖 공간을 보장했다.
- 맞게 했다고 생각함에도 불구하고, 런타임 에러와 메모리초과가 나왔다.
- 최소화하도록 노력했으나 dfs의 한계인 듯 하다
|테스트 1 〉|통과 (42.75ms, 67.3MB)|
|테스트 2 〉|통과 (49.85ms, 71.9MB)|
|테스트 3 〉|통과 (52.10ms, 78.5MB)|
|테스트 4 〉|통과 (173.23ms, 95.6MB)|
|테스트 5 〉|실패 (런타임 에러)|
|테스트 6 〉|통과 (215.25ms, 91.3MB)|
|테스트 7 〉|실패 (런타임 에러)|
|테스트 8 〉|실패 (메모리 초과)|
|테스트 9 〉|실패 (메모리 초과)|
### Pseudo Code
```kotlin
val width = maxX - minX + 3
val height = maxY - minY + 3
val map = Array(height) { IntArray(width) }
val visited = Array(height) { BooleanArray(width) }

var x = -minX + 1
var y = -minY + 1
map[y][x] = 1
arrows.forEach { arrow ->
	repeat(4) {
		x += dir[arrow][0]
		y += dir[arrow][1]
		map[y][x] = 1
	}
}

fun dfs(i: Int, j: Int) {
	visited[i][j] = true
	dir.filterIndexed { idx, it ->
		idx % 2 != 1
	}.forEach {
		val x = j + it[0]
		val y = i + it[1]
		if (y in map.indices && x in map[y].indices &&
			!visited[y][x] && map[y][x] == 0)
			dfs(y, x)
	}
}
map.forEachIndexed { i, it ->
	it.indices.forEach { j ->
		if (!visited[i][j] && map[i][j] == 0) {
			answer++
			dfs(i, j)
		}
	}
}

return answer
```

### 메모리
### 시간