### PR TITLE
APR_week3_wizard_shark_and_wish_rain_cloud

### DIFF
--- a/apr_week3/wizard_shark_and_wish_rain_cloud.kt
+++ b/apr_week3/wizard_shark_and_wish_rain_cloud.kt
@@ -1,0 +1,53 @@
+package com.example.algorithm
+
+fun main() {
+    val (n, m) = readln().split(" ").map { it.toInt() }
+    val map = Array(n) {
+        readln().split(" ").map { it.toInt() }.toMutableList()
+    }
+    val orders = Array(m) {
+        readln().split(" ").map { it.toInt() }
+    }
+    var clouds = mutableListOf(n to 1, n to 2, n-1 to 1, n-1 to 2)
+    val dx = listOf(0, -1, -1, 0, 1, 1, 1, 0, -1)
+    val dy = listOf(0, 0, -1, -1, -1, 0, 1, 1, 1) // 5분
+
+    fun circularCalc(newCoord: Int): Int {
+        var ret = newCoord % n
+        if (ret > 0)
+            return ret
+        return ret + n
+    }
+    orders.forEach { (d, s) ->
+        clouds.replaceAll { (y, x) ->
+            circularCalc(y + dy[d] * s) to circularCalc(x + dx[d] * s)
+        } // 45분
+        clouds.forEach { (i, j) ->
+            map[i-1][j-1]++
+        }
+        clouds.forEach { (ci, cj) ->
+            val i = ci - 1
+            val j = cj - 1
+            if (i-1 in 0 until n && j-1 in 0 until n && map[i-1][j-1] > 0)
+                map[i][j]++
+            if (i-1 in 0 until n && j+1 in 0 until n && map[i-1][j+1] > 0)
+                map[i][j]++
+            if (i+1 in 0 until n && j-1 in 0 until n && map[i+1][j-1] > 0)
+                map[i][j]++
+            if (i+1 in 0 until n && j+1 in 0 until n && map[i+1][j+1] > 0)
+                map[i][j]++
+        }
+        val newClouds = mutableListOf<Pair<Int, Int>>()
+        val cloudsSet = clouds.toSet()
+        map.forEachIndexed { i, it ->
+            it.forEachIndexed { j, jt ->
+                if (jt >= 2 && !cloudsSet.contains(i+1 to j+1)) {
+                    newClouds.add(i+1 to j+1)
+                    map[i][j] -= 2
+                }
+            }
+        }
+        clouds = newClouds
+    }
+    print(map.sumOf { it.sum() })
+}


### PR DESCRIPTION
## 마법사 상어와 비바라기

### 소요 시간
> 1시간 15분
### 간단 풀이 방식
- 구현 문제라 하라는 대로 구현했다.
- 좌표값을 가지고 있는 리스트로 구름을 관리했다.
### 고민파트
- 인덱스를 넘어가는 큰 수는 배열 크기만큼 나머지 연산해주면 된다는 것을 안다.
	- 하지만, 음수로 내려가는 인덱스는 관리해본 적이 없어 고민을 오래했다.
	- 게다가 좌표가 zero-based가 아니여서 조금 더 고민했으나, 0이하(zero-based면 음수)인 경우, 나머지 연산 후 배열 크기만큼 더하는 것으로 해결했다.(fun circularCalc)
- 문제에 적혀있는 진행 순서 중 2번과 4번은 엄연한 순서차이가 있으나, 이를 한 반복에 다 처리하려 했었다.
	- 그 결과, 앞으로 구름으로 인해 물양이 0에서 1이 될 바구니에 대하여, 물이 없다고 판단해버렸다.
	- 때문에 순차적으로 진행될 수 있도록 반복을 분리했다.
- 이 문제 또한 시간초과가 났었다. clouds를 newClouds로 갱신하는 과정에서, map을 순회하는 이중반복 안에 clouds 속 존재 여부를 확인하는 로직 때문이었다.
	- 이미 $n^2$ 인데 List.contains를 사용하면, * List.size를 하는 것이였다.
	- 때문에 O(1) 검색을 위한, List를 Set(HashSet도 가능)으로 바꾼 cloudsSet을 만들어 사용했다.
	- 덕분에 $n^2$ 으로 방어했고, 통과했다.
### Pseudo Code
```kotlin
fun circularCalc(newCoord: Int): Int {
	var ret = newCoord % n
	if (ret > 0)
		return ret
	return ret + n
}
orders.forEach { (d, s) ->
	clouds.replaceAll { (y, x) ->
		circularCalc(y + dy[d] * s) to circularCalc(x + dx[d] * s)
	}
	clouds.forEach { (i, j) ->
		map[i-1][j-1]++
	}
	clouds.forEach { (ci, cj) ->
		val i = ci - 1
		val j = cj - 1
		if (i-1 in 0 until n && j-1 in 0 until n && map[i-1][j-1] > 0)
			map[i][j]++
		if (i-1 in 0 until n && j+1 in 0 until n && map[i-1][j+1] > 0)
			map[i][j]++
		if (i+1 in 0 until n && j-1 in 0 until n && map[i+1][j-1] > 0)
			map[i][j]++
		if (i+1 in 0 until n && j+1 in 0 until n && map[i+1][j+1] > 0)
			map[i][j]++
	}
	val newClouds = mutableListOf<Pair<Int, Int>>()
	val cloudsSet = clouds.toSet()
	map.forEachIndexed { i, it ->
		it.forEachIndexed { j, jt ->
			if (jt >= 2 && !cloudsSet.contains(i+1 to j+1)) {
				newClouds.add(i+1 to j+1)
				map[i][j] -= 2
			}
		}
	}
	clouds = newClouds
}
print(map.sumOf { it.sum() })
```
