### PR TITLE
Apr week3 population movement

### DIFF
--- a/apr_week3/population_movement.kt
+++ b/apr_week3/population_movement.kt
@@ -1,0 +1,60 @@
+fun main() {
+    val (n, l, r) = readln().split(" ").map { it.toInt() }
+    val map = Array(n) {
+        readln().split(" ").map { it.toInt() }.toMutableList()
+    }
+
+    val dx = listOf(0, 0, -1, 1)
+    val dy = listOf(-1, 1, 0, 0)
+    var visited = map.map {
+        BooleanArray(it.size)
+    }.toTypedArray()
+
+    fun dfs(i: Int, j: Int): Pair<List<Pair<Int, Int>>, Boolean> {
+        var route = listOf(i to j)
+        var adj = false
+        visited[i][j] = true
+        (0..3).forEach {
+            val mi = i + dy[it]
+            val mj = j + dx[it]
+            if (mi in map.indices && mj in map.indices
+                && Math.abs(map[i][j] - map[mi][mj]) in l..r
+                && !visited[mi][mj]) {
+                adj = true
+                route += dfs(mi, mj).first
+            }
+        }
+        return route to adj
+    }
+    fun move_pop(route: List<Pair<Int, Int>>){
+        val avg = route.sumOf { (i, j) ->
+            map[i][j]
+        } / route.size
+        route.forEach { (i, j) ->
+            map[i][j] = avg
+        }
+    }
+
+    var answer = 0
+    var move = true
+    while (move) {
+        move = false
+        visited = map.map {
+            BooleanArray(it.size)
+        }.toTypedArray()
+        map.indices.forEach { i ->
+            map[i].indices.forEach { j ->
+                if (!visited[i][j]) {
+                    val (route, adj) = dfs(i, j)
+                    if (adj) {
+                        move = true
+                        move_pop(route)
+                    }
+                }
+            }
+        }
+        if (move)
+            answer++
+    }
+    print(answer) // 1시간 반
+}

--- a/apr_week3/population_movement.kt
+++ b/apr_week3/population_movement.kt
@@ -6,9 +6,7 @@ fun main() {
 
     val dx = listOf(0, 0, -1, 1)
     val dy = listOf(-1, 1, 0, 0)
-    var visited = map.map {
-        BooleanArray(it.size)
-    }.toTypedArray()
+    var visited = arrayOf<BooleanArray>()
 
     fun dfs(i: Int, j: Int): Pair<List<Pair<Int, Int>>, Boolean> {
         var route = listOf(i to j)
@@ -56,5 +54,5 @@ fun main() {
         if (move)
             answer++
     }
-    print(answer) // 1시간 반
+    print(answer)
 }


### PR DESCRIPTION
## 인구 이동
### 소요 시간
> 1시간 반
### 간단 풀이 방식
- 네트워크 문제풀이 처럼 dfs를 map의 모든 요소(나라)에 대하여 수행했다.
	- dfs는 국경을 열어야하는 나라를 인접노드로 판단하여 쭉 수행한다.
		- dfs의 반환값은 Pair<dfs방문경로, 국경이 열려있는 나라가 있는지>이다.
- 현재 나라에 국경이 열려있는 나라가 존재한다면
	- dfs의 반환값인 방문경로를 통해, 국경이 열려있는 나라들간의 인구 이동을 수행한다.
	- 또한 한 번이라도 인구이동을 수행했다는 flag(move)를 true로 바꾼다.
- 이처럼 map을 모두 순회하며
	- 한 번이라도 인구이동을 했다면, answer를 증가시킨다.
	- 위 동작을 단 한 번도 인구이동을 하지 않을 때까지 반복한다.
### 고민파트
- dfs를 사용하여 국경이 열린 나라들을 순회하는 것까진 쉽게 생각했지만, 어떻게 현재 dfs에 대해서만 평균값을 구하고, 인구수를 바꿀지 고민을 많이 했다.
	- 처음엔 visited를 0,1,2로 이루어지게 하여, 한번도 방문하지 않음,방문은 했으나 인구이동 아직 안 함,인구이동까지 다 함 으로 구분하려 했다.
	- 그러나 인구이동을 수행하려면 어차피 경로를 알아야겠다는 생각에 이 로직으로 변경했다.
- 언제까지 인구이동 회차를 늘려야하는지는, 1차 인구이동을 수행하고 나니 자연스럽게 생각났다.
- 로직 상 어쩔 수 없이 visited를 인구이동을 하는 날마다 초기화하였는데, 이게 맞는 방법인지 해본 적 없는 로직이라 의심됐다.
	- 다행히 한 방에 잘 됐다.
### Pseudo Code
```kotlin
fun dfs(i: Int, j: Int): Pair<List<Pair<Int, Int>>, Boolean> {
	var route = listOf(i to j)
	var adj = false
	visited[i][j] = true
	(0..3).forEach {
		val mi = i + dy[it]
		val mj = j + dx[it]
		if (mi in map.indices && mj in map.indices
			&& Math.abs(map[i][j] - map[mi][mj]) in l..r
			&& !visited[mi][mj]) {
			adj = true
			route += dfs(mi, mj).first
		}
	}
	return route to adj
}
fun move_pop(route: List<Pair<Int, Int>>){
	val avg = route.sumOf { (i, j) ->
		map[i][j]
	} / route.size
	route.forEach { (i, j) ->
		map[i][j] = avg
	}
}

var answer = 0
var move = true
while (move) {
	move = false
	visited = map.map {
		BooleanArray(it.size)
	}.toTypedArray()
	map.indices.forEach { i ->
		map[i].indices.forEach { j ->
			if (!visited[i][j]) {
				val (route, adj) = dfs(i, j)
				if (adj) {
					move = true
					move_pop(route)
				}
			}
		}
	}
	if (move)
		answer++
}
print(answer)
```
